### PR TITLE
locale.conf bugfix in base.Dockerfile

### DIFF
--- a/linux/base.Dockerfile
+++ b/linux/base.Dockerfile
@@ -151,7 +151,7 @@ RUN TF_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform
   && unset TF_VERSION
 
 # Setup locale to en_US.utf8
-RUN echo en_US UTF-8 >> /etc/locale.conf && locale-gen.sh
+RUN echo 'LANG=en_US.UTF-8' >> /etc/locale.conf && locale-gen.sh
 ENV LANG="en_US.utf8"
 
 # # BEGIN: Install Ansible in isolated Virtual Environment


### PR DESCRIPTION
The file /etc/locale.conf contained incorrect data. 

With this minor change the errors in login shells such as tmux should be fixed. As [this issue](https://github.com/Azure/CloudShell/issues/388) is a couple months old, I thought I'd pitch in. 

Feedback is appreciated :)